### PR TITLE
Add 1.02 Annex 2 draft ITS templante constraint

### DIFF
--- a/npl_portfolio/counterparty.py
+++ b/npl_portfolio/counterparty.py
@@ -343,3 +343,4 @@ class Counterparty(models.Model):
     class Meta:
         verbose_name = "Counterparty"
         verbose_name_plural = "Counterparties"
+        unique_together = [['portfolio_id', 'counterparty_identifier']]


### PR DESCRIPTION
"This value cannot be used as the counterparty identifier for any other counterparty."

From: https://www.eba.europa.eu/legacy/regulation-and-policy/regulatory-activities/credit-risk/implementing-technical-standards-npl

Annex 2 point 1.02

A single transaction cannot have twice the same counterparty identifier.